### PR TITLE
adds xlink paste support and fixes xlink multicolor mode switching

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -100,7 +100,11 @@ PasteCommand::PasteCommand(State *state, int charIndex, const State::CopyRange& 
 
 void PasteCommand::undo()
 {
-    _state->updateCharset(_origBuffer);
+    State::CopyRange reversedCopyRange;
+    memcpy(&reversedCopyRange, &_copyRange, sizeof(State::CopyRange));
+    reversedCopyRange.offset = _charIndex;
+
+    _state->paste(_charIndex, reversedCopyRange, _origBuffer);
 }
 
 void PasteCommand::redo()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -188,14 +188,16 @@ void MainWindow::createActions()
     auto preview = Preview::getInstance();
     connect(state, SIGNAL(fileLoaded()), preview, SLOT(fileLoaded()));
     connect(state, SIGNAL(byteUpdated(int)), preview, SLOT(byteUpdated(int)));
+    connect(state, SIGNAL(bytesUpdated(int, int)), preview, SLOT(bytesUpdated(int, int)));
     connect(state, SIGNAL(tileUpdated(int)), preview, SLOT(tileUpdated(int)));
+    connect(state, SIGNAL(colorPropertiesUpdated(int)), preview, SLOT(colorPropertiesUpdated()));
+    connect(state, SIGNAL(multicolorModeToggled(bool)), preview, SLOT(colorPropertiesUpdated()));
 
     connect(state, SIGNAL(byteUpdated(int)), this, SLOT(updateWindow()));
     connect(state, SIGNAL(tileUpdated(int)), this, SLOT(updateWindow()));
     connect(state, SIGNAL(charIndexUpdated(int)), this, SLOT(charIndexUpdated(int)));
     connect(state, SIGNAL(charsetUpdated()), this, SLOT(updateWindow()));
 
-//  connect(state, SIGNAL(colorPropertiesUpdated(int)), preview, SLOT(tileWasUpdated()));
     connect(state, SIGNAL(colorPropertiesUpdated(int)), this, SLOT(updateWindow()));
     connect(state, SIGNAL(multicolorModeToggled(bool)), this, SLOT(multicolorModeToggled(bool)));
     connect(state, SIGNAL(contentsChanged()), this, SLOT(documentWasModified()));

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -191,6 +191,14 @@ void Preview::byteUpdated(int byteIndex)
     xlink_poke(0xb7, 0x00, 0x3000 + byteIndex, state->getCharsetBuffer()[byteIndex]);
 }
 
+void Preview::bytesUpdated(int pos, int count)
+{
+    if(!isConnected()) return;
+
+    auto state = State::getInstance();
+    xlink_load(0xb7, 0x00, 0x3000+pos, state->getCharsetBuffer()+pos, count);
+}
+
 void Preview::tileUpdated(int tileIndex)
 {
     if(!isConnected()) return;

--- a/src/preview.h
+++ b/src/preview.h
@@ -62,6 +62,9 @@ public slots:
     // when one byte in a part of the tile changes
     void byteUpdated(int);
 
+    // when a range of bytes in the charset changes (e.g. due to a paste)
+    void bytesUpdated(int pos, int count);
+
     // when the whole tile changes
     void tileUpdated(int);
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -483,6 +483,7 @@ void State::paste(int charIndex, const CopyRange& copyRange, const quint8* chars
         if (bytesToCopy <0)
             break;
         memcpy(dst, src, bytesToCopy);
+        emit bytesUpdated(charIndex * 8, bytesToCopy);
 
         dst += (copyRange.blockSize + copyRange.skip) * 8;
         src += (copyRange.blockSize + copyRange.skip) * 8;

--- a/src/state.h
+++ b/src/state.h
@@ -238,6 +238,9 @@ signals:
     // when one byte in a part of the tile changes
     void byteUpdated(int);
 
+    // when a range of bytes in the charset changes (e.g. due to a paste)
+    void bytesUpdated(int pos, int count);
+
     // when the whole tile changes
     void tileUpdated(int);
 


### PR DESCRIPTION
This pull request introduces the signal bytesUpdated(int pos, int count) which can be emitted when a range of consecutive bytes in the charset changes. It is emitted during State::paste for each consecutive range of bytes and is handled by Preview::bytesUpdated, which transfers the corresponding bytes to C64 memory. Thus all paste actions are reflected on the C64.

In addition, PasteCommand::undo has been refactored to also use the State::paste method instead of simply copying back the whole _origBuffer to the charset. The reverse operation of the original paste is performed by constructing a temporary State::CopyRange  and using the original _charIndex as the offset. This way the charset does not need to be transferred to the C64 as a whole for each undo of a paste (which would have been the method corresponding to the existing implementation).

I have also (re)connected both colorPropertiesUpdated and multicolorModeChanged signals to Preview::colorPropertiesChanged in order to reenable switching between color modes on the C64.