### PR TITLE
Fixes build for gcc 7.1+

### DIFF
--- a/src/importkoaladialog.cpp
+++ b/src/importkoaladialog.cpp
@@ -213,7 +213,7 @@ bool ImportKoalaDialog::tryChangeKey(int x, int y, char* key, quint8 mask, int h
 
         for (int i=0; i<totalMasks; ++i)
         {
-            if (mask && (1<<i))
+            if (mask && (1<<i) != 0)
             {
                 int xdiff = masks[i][0];
                 int ydiff = masks[i][1];

--- a/src/stateexport.cpp
+++ b/src/stateexport.cpp
@@ -30,7 +30,7 @@ qint64 StateExport::saveVChar64(State* state, QFile& file)
 {
     StateImport::VChar64Header header;
 
-    strncpy(header.id, "VChar", 5);
+    strcpy(header.id, "VChar");
 
     header.version = 3;
 


### PR DESCRIPTION
Fixes #51.
Both lines emit warnings treated as errors in gcc 8 (and 7.1 I assume).

Tested on:
- Fedora 28
- gcc 8.1.1
- qt 5.10.1