### PR TITLE
Fix spinbox-selected tile not updating the selected map cell

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -36,6 +36,7 @@ limitations under the License.
 #include <QMimeData>
 #include <QRadioButton>
 #include <QScreen>
+#include <QSignalBlocker>
 #include <QSpinBox>
 #include <QStyle>
 #include <QToolBar>
@@ -393,7 +394,13 @@ BigCharWidget* MainWindow::createDocument(State* state)
     connect(state, &State::tileIndexUpdated, _ui->tilesetWidget, &TilesetWidget::onTileIndexUpdated);
     connect(state, &State::tileIndexUpdated, bigcharWidget, &BigCharWidget::onTileIndexUpdated);
     connect(state, &State::charIndexUpdated, _ui->charsetWidget, &CharsetWidget::onCharIndexUpdated);
-    connect(state, &State::tileIndexUpdated, _ui->spinBox_tileIndex, &QSpinBox::setValue);
+    connect(state, &State::tileIndexUpdated, this, [this](int tileIndex) {
+        // Block signals: this is a read-only sync (e.g. clicking a tile/map cell) and must not
+        // re-trigger onSpinBoxValueChanged(), which would otherwise treat it as a user edit and
+        // paint the current map selection with its own unchanged value.
+        const QSignalBlocker blocker(_ui->spinBox_tileIndex);
+        _ui->spinBox_tileIndex->setValue(tileIndex);
+    });
 
     connect(state->getUndoStack(), &QUndoStack::indexChanged, this, &MainWindow::documentWasModified);
     connect(state->getUndoStack(), &QUndoStack::cleanChanged, this, &MainWindow::documentWasModified);
@@ -1513,6 +1520,12 @@ void MainWindow::onSpinBoxValueChanged(int tileIndex)
     auto state = getState();
     if (state) {
         state->setTileIndex(tileIndex);
+
+        // If a map cell is currently selected, editing the tile index should replace that
+        // cell's tile too, mirroring what typing a character directly on the map does.
+        if (_lastFocusedEditorWidget == _ui->mapWidget && _ui->mapWidget->getMode() == MapWidget::SELECT_MODE) {
+            state->mapPaint(_ui->mapWidget->getCursorCoord(), tileIndex, false);
+        }
     }
 }
 

--- a/src/mapwidget.h
+++ b/src/mapwidget.h
@@ -40,10 +40,12 @@ public:
 
     void enableGrid(bool enabled);
     void setMode(MapMode mode);
+    MapMode getMode() const { return _mode; }
     void setZoomLevel(int zoomLevel);
 
     void getSelectionRange(State::CopyRange* copyRange) const;
     int getCursorPos() const;
+    QPoint getCursorCoord() const { return _cursorPos; }
 
     std::unique_ptr<QImage> renderToQImage();
 


### PR DESCRIPTION
## Summary
- Editing the tile-index spinbox while a map cell is selected now actually repaints that cell with the newly chosen tile, mirroring what typing a character directly on the map already does.
- The `tileIndexUpdated -> spinBox_tileIndex` sync is now wrapped in a `QSignalBlocker`, so read-only syncs (e.g. clicking a tile in the tileset picker, or clicking/moving the cursor on the map) don't loop back into `onSpinBoxValueChanged()` and spuriously repaint the map with an unchanged value.

## Test plan
- [x] Builds cleanly (`cmake --build .`)
- [x] `ctest` passes (test_stateimport, test_stateexport)
- [ ] Manual: select a map cell in Select mode, change the tile-index spinbox value, confirm the map cell updates
- [ ] Manual: click through tiles in the tileset picker without a map cell selected, confirm no spurious map edits/undo entries are created